### PR TITLE
Add namespace parameter, serviceAccount, some doc and a small Makefil…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	@echo "Manual launch commands:"
 	@echo "  make params      # Display configuration options"
-	@echo "  make optoins     # Display the override options.env"
+	@echo "  make options     # Display the override options.env"
 	@echo "  make running     # Manually launch Running"
 	@echo "  make hibernating # Manually launch Hibernating"
 	@echo "  make cronjobs    # Deploys the CronJobs"
@@ -41,22 +41,22 @@ clean: checks
 	docker image rm ${REPO_URL}/hibernation-curator:${VERSION}
 
 running: options.env
-	oc process -f templates/running-job.yaml --param-file options.env  | oc apply -f -
+	oc process -f templates/running-job.yaml --param-file options.env --ignore-unknown-parameters=true | oc apply -f -
 
 hibernating: options.env
-	oc process -f templates/hibernating-job.yaml --param-file options.env  | oc apply -f -
+	oc process -f templates/hibernating-job.yaml --param-file options.env --ignore-unknown-parameters=true  | oc apply -f -
 
 cronjobs: options.env
-	oc process -f templates/cronjobs.yaml --param-file options.env  | oc apply -f -
+	oc process -f templates/cronjobs.yaml --param-file options.env --ignore-unknown-parameters=true  | oc apply -f -
 
 clean-cronjobs: options.env
-	oc process -f templates/cronjobs.yaml --param-file options.env  | oc delete -f -
+	oc process -f templates/cronjobs.yaml --param-file options.env --ignore-unknown-parameters=true  | oc delete -f -
 
 roles: options.env
-	oc process -f templates/roles.yaml --param-file options.env | oc apply -f -
+	oc process -f templates/roles.yaml --param-file options.env --ignore-unknown-parameters=true | oc apply -f -
 
 clean-roles: options.env
-	oc process -f templates/roles.yaml --param-file options.env | oc delete -f -
+	oc process -f templates/roles.yaml --param-file options.env --ignore-unknown-parameters=true | oc delete -f -
 
 compile:
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,10 @@ clean-cronjobs: options.env
 	oc process -f templates/cronjobs.yaml --param-file options.env  | oc delete -f -
 
 roles: options.env
-	oc process -f templates/roles.yaml -p NAMESPACE=`oc project -q` | oc apply -f -
+	oc process -f templates/roles.yaml --param-file options.env | oc apply -f -
 
 clean-roles: options.env
-	oc process -f templates/roles.yaml -p NAMESPACE=`oc project -q` | oc delete -f -
+	oc process -f templates/roles.yaml --param-file options.env | oc delete -f -
 
 compile:
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 all:
 	@echo "Manual launch commands:"
-	@echo "  make params     # Display configuration options"
-	@echo "  make optoins    # Display the override options.env"
-	@echo "  make running    # Manually launch Running"
-	@echo "  make hibernate  # Manually launch Hibernating"
-	@echo "  make cronjobs   # Deploys the CronJobs"
-	@echo "  make roles      # Deploys the ClusterRole and ClusterRoleBinding"
+	@echo "  make params      # Display configuration options"
+	@echo "  make optoins     # Display the override options.env"
+	@echo "  make running     # Manually launch Running"
+	@echo "  make hibernating # Manually launch Hibernating"
+	@echo "  make cronjobs    # Deploys the CronJobs"
+	@echo "  make roles       # Deploys the ClusterRole and ClusterRoleBinding"
 	@echo ""
 	@echo "Development commands"
 	@echo "  make compile    # Compile code"
@@ -43,7 +43,7 @@ clean: checks
 running: options.env
 	oc process -f templates/running-job.yaml --param-file options.env  | oc apply -f -
 
-hibernate: options.env
+hibernating: options.env
 	oc process -f templates/hibernating-job.yaml --param-file options.env  | oc apply -f -
 
 cronjobs: options.env

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all:
 	@echo "Manual launch commands:"
 	@echo "  make params     # Display configuration options"
+	@echo "  make optoins    # Display the override options.env"
 	@echo "  make running    # Manually launch Running"
 	@echo "  make hibernate  # Manually launch Hibernating"
 	@echo "  make cronjobs   # Deploys the CronJobs"
@@ -29,6 +30,10 @@ endif
 options.env:
 	touch options.env
 
+options:
+	@cat ./options.env
+	@echo ""
+
 params:
 	oc process -f templates/cronjobs.yaml --parameters
 
@@ -38,7 +43,7 @@ clean: checks
 running: options.env
 	oc process -f templates/running-job.yaml --param-file options.env  | oc apply -f -
 
-hibernating: options.env
+hibernate: options.env
 	oc process -f templates/hibernating-job.yaml --param-file options.env  | oc apply -f -
 
 cronjobs: options.env

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This repository has the source code as well as the deployment for two Kubernetes
 ## Requirements
 - Red Hat Advanced Cluster Management for Kubernetes 2.1
 - OpenShift 4.5 and 4.6 clusters provisioned by ACM
+- Add the `NAMEPSPACE` parameter, pointing to where you want to run the hibernation jobs, in the `./options.env` file
+```bash
+# ./options.env
+NAMESPACE: open-cluster-management  #This can be any namespace where you want to install
+```
 
 ## Deploy
 1. Log into your ACM Hub on OpenShift and make sure `oc project -q` displays the name of the namespace where you want to install.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ NAMESPACE: open-cluster-management  #This can be any namespace where you want to
 ```
 
 ## Deploy
-1. Log into your ACM Hub on OpenShift and make sure `oc project -q` displays the name of the namespace where you want to install.
+1. Log into your ACM Hub on OpenShift
 2. Run the command:
    ```
    make cronjobs

--- a/templates/cronjobs.yaml
+++ b/templates/cronjobs.yaml
@@ -7,6 +7,7 @@ objects:
     kind: ServiceAccount
     metadata:
       name: hibernator
+      namespace: ${NAMESPACE}
   - apiVersion: batch/v1beta1
     kind: CronJob
     metadata:
@@ -34,6 +35,7 @@ objects:
     kind: CronJob
     metadata:
       name: running-cronjob
+      namespace: ${NAMESPACE}
     spec:
       schedule: ${RUNNING_SCHEDULE}
       suspend: ${{RUNNING_DISABLED}}
@@ -77,4 +79,7 @@ parameters:
   - name: CURATOR_IMAGE
     description: Hibernation curator image
     value: quay.io/jpacker/hibernation-curator:latest
+    required: true
+  - name: NAMESPACE 
+    description: The namespace where the hibernate CronJobs were installed
     required: true

--- a/templates/hibernating-job.yaml
+++ b/templates/hibernating-job.yaml
@@ -35,14 +35,6 @@ parameters:
   - name: RANDOM_ID
     generate: expression
     from: "[a-z0-9]{5}"
-  - name: HIBERNATION_SCHEDULE 
-    description: Not used; allows sharing of options.env file
-  - name: RUNNING_SCHEDULE 
-    description: Not used; allows sharing of options.env file
-  - name: HIBERNATION_DISABLED
-    description: Not used; allows sharing of options.env file
-  - name: RUNNING_DISABLED
-    description: Not used; allows sharing of options.env file
   - name: NAMESPACE 
     description: The namespace where the hibernate CronJobs were installed
     required: true

--- a/templates/hibernating-job.yaml
+++ b/templates/hibernating-job.yaml
@@ -7,6 +7,7 @@ objects:
     kind: Job
     metadata:
       name: hibernating-job-${RANDOM_ID}
+      namespace: ${NAMESPACE}
     spec:
       template:
         spec:
@@ -42,3 +43,6 @@ parameters:
     description: Not used; allows sharing of options.env file
   - name: RUNNING_DISABLED
     description: Not used; allows sharing of options.env file
+  - name: NAMESPACE 
+    description: The namespace where the hibernate CronJobs were installed
+    required: true

--- a/templates/roles.yaml
+++ b/templates/roles.yaml
@@ -18,6 +18,7 @@ objects:
     kind: ClusterRoleBinding
     metadata:
         name: hibernation-curator
+        namespace: ${NAMESPACE}
     subjects:
     - kind: ServiceAccount
       name: hibernator

--- a/templates/roles.yaml
+++ b/templates/roles.yaml
@@ -26,6 +26,11 @@ objects:
       kind: ClusterRole
       name: hibernation-curator
       apiGroup: rbac.authorization.k8s.io
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: hibernator
+      namespace: ${NAMESPACE}
 parameters:
   - name: NAMESPACE 
     description: The namespace where the hibernate CronJobs were installed

--- a/templates/running-job.yaml
+++ b/templates/running-job.yaml
@@ -35,14 +35,6 @@ parameters:
   - name: RANDOM_ID
     generate: expression
     from: "[a-z0-9]{5}"
-  - name: HIBERNATION_SCHEDULE 
-    description: Not used; allows sharing of options.env file
-  - name: RUNNING_SCHEDULE 
-    description: Not used; allows sharing of options.env file
-  - name: HIBERNATION_DISABLED
-    description: Not used; allows sharing of options.env file
-  - name: RUNNING_DISABLED
-    description: Not used; allows sharing of options.env file
   - name: NAMESPACE 
     description: The namespace where the hibernate CronJobs were installed
     required: true

--- a/templates/running-job.yaml
+++ b/templates/running-job.yaml
@@ -7,6 +7,7 @@ objects:
     kind: Job
     metadata:
       name: running-job-${RANDOM_ID}
+      namespace: ${NAMESPACE}
     spec:
       template:
         spec:
@@ -42,3 +43,6 @@ parameters:
     description: Not used; allows sharing of options.env file
   - name: RUNNING_DISABLED
     description: Not used; allows sharing of options.env file
+  - name: NAMESPACE 
+    description: The namespace where the hibernate CronJobs were installed
+    required: true


### PR DESCRIPTION
Changes:
- Added some extra details to README
- Add `make options` for looking at your settings
- Fix hibernate make target, not matching make command reference
- Added namespace so the jobs and cronjobs, as they were being created in the current context naemspace.  Not sure I'm sold on this, but I believe its better then having them all over the Hub cluster.