### PR TITLE
Fix missing namespace binding and add ttl for jobs.

### DIFF
--- a/templates/cronjobs.yaml
+++ b/templates/cronjobs.yaml
@@ -12,6 +12,7 @@ objects:
     kind: CronJob
     metadata:
       name: hibernation-cronjob
+      namespace: ${NAMESPACE}
     spec:
       schedule: ${HIBERNATION_SCHEDULE}
       suspend: ${{HIBERNATION_DISABLED}}

--- a/templates/hibernating-job.yaml
+++ b/templates/hibernating-job.yaml
@@ -9,6 +9,7 @@ objects:
       name: hibernating-job-${RANDOM_ID}
       namespace: ${NAMESPACE}
     spec:
+      ttlSecondsAfterFinished: 600
       template:
         spec:
           serviceAccountName: hibernator

--- a/templates/running-job.yaml
+++ b/templates/running-job.yaml
@@ -9,6 +9,7 @@ objects:
       name: running-job-${RANDOM_ID}
       namespace: ${NAMESPACE}
     spec:
+      ttlSecondsAfterFinished: 600
       template:
         spec:
           serviceAccountName: hibernator


### PR DESCRIPTION
Signed by @jnpacker 

* Add namespace to the hibernate cronjob definition
* Add ttl for the jobs